### PR TITLE
Commit for adding tasks_per_job to oanger

### DIFF
--- a/onager/backends/_backend.py
+++ b/onager/backends/_backend.py
@@ -16,13 +16,18 @@ class Backend:
 
         self.task_id_var = r'$TASK_ID'
 
+    def _get_body(self, tasks_file, args):
+        body = self.body.format(tasks_file, self.task_id_var)
+        return body
+
     def wrap_tasks(self, tasks_file, args):
         config = get_active_config()
         header = '\n'.join((self.header, config[self.name]['header']))
         if args.venv is not None:
             venv_activate_path = os.path.join(os.path.normpath(args.venv), 'bin', 'activate')
             header = '\n'.join((header, 'source {}'.format(venv_activate_path)))
-        body = self.body.format(tasks_file, self.task_id_var)
+        body = self._get_body(tasks_file, args)
+        # body = self.body.format(tasks_file, self.task_id_var)
         footer = '\n'.join((config[self.name]['footer'], self.footer))
         wrapper_script = header + body + footer
         return wrapper_script

--- a/onager/frontend.py
+++ b/onager/frontend.py
@@ -52,6 +52,8 @@ def parse_args(args=None):
         help='Number of GPUs to request')
     launch_parser.add_argument('--mem', type=int, default=2,
         help='Amount of RAM (in GB) to request per node')
+    launch_parser.add_argument('--tasks_per_job', type=int, default=1,
+        help='Number of processes to run per job. Useful for full utilization of GPU')
     launch_parser.add_argument('--venv', type=str, default=None,
         help='Path to python virtualenv')
     launch_parser.add_argument('--duration', type=str, default='0-01:00:00',

--- a/onager/worker.py
+++ b/onager/worker.py
@@ -23,8 +23,10 @@ if __name__ == '__main__':
     assert len(sys.argv) == 3, 'Usage: python -m worker path/to/commands.json task_id'
     
     commands_file = sys.argv[1]
-    task_id = int(sys.argv[2])
-
-    commands = load_jobfile(commands_file)[0]
-
-    run_command_by_id(commands, task_id)
+    task_id = sys.argv[2]
+    if task_id == "__filler__":
+        pass # From the task list thing.
+    else:
+        task_id = int(task_id)
+        commands = load_jobfile(commands_file)[0]
+        run_command_by_id(commands, task_id)


### PR DESCRIPTION
By passing `--tasks-per-job` to `onager launch`, lets you run multiple tasks using the same resources. For example, running 2 tasks on one GPU. Silently ignored on non-slurm.

Main current limitation is that it sends all logs in a job to the same place. So, if you have 2 tasks in the same job the logs can be jumbled and confusing. Also, my feeling is that when tasks_per_job is 1, it would be better to make wrapper.sh look like it used to for simplicity.