### PR TITLE
Release v0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,45 @@ myscript --learningrate 0.01 --batchsize 128 --mytag experiment1_8__learningrate
 myscript --learningrate 0.001 --batchsize 128 --mytag experiment1_9__learningrate_0.001__batchsize_128
 ```
 
+Argument types:
+```
++arg --argname [value ...]
+```
+- Add an argument with zero or more mutually exclusive values
+
+```
++pos-arg value [value ...]
+```
+
+- Add a positional argument with one or more mutually exclusive values
+
+```
++flag --flagname
+```
+
+- Add a boolean argument that will be toggled in the resulting commands
+
+
+Options:
+```
++tag [TAG]
+```
+
+- Passes a unique tag string for each run to the specified arg in the command, i.e. `--tag <tag-contents>`.
+
+```
++tag-args --argname [--argname ...]
+```
+
+- Specifies which args go into the unique `<tag-contents>`. Default is all provided args.
+
+```
++no-tag-number
+```
+
+- Disable auto-numbering when generating tags
+
+
 ### Launch
 Launch reads a jobfile (or accepts a single user-specified command), and launches the associated job(s) on the specified backend. Currently onager supports 'slurm' and 'gridengine' as cluster backends, and 'local' for running on a single host.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,25 @@ Output:
 sbatch -J experiment1 -t 0-01:00:00 -n 1 -p batch --mem=2G -o .onager/logs/slurm/%x_%A_%a.o -e .onager/logs/slurm/%x_%A_%a.e --parsable --array=1,2,3,4,5,6,7,8,9 .onager/scripts/experiment1/wrapper.sh
 ```
 
+Options:
+```
+--max-tasks MAX_TASKS
+```
+
+- Maximum number of simultaneous tasks on backend. This argument can be used to limit the number of jobs to avoid flooding the cluster or to override the default parallelism of the local backend. When `--tasks-per-node` is greater than 1, `--max-tasks` governs the number of nodes, and `--max-tasks-per-node` governs the number of tasks per node.
+
+```
+--tasks-per-node TASKS_PER_NODE
+```
+
+- Enables running multiple tasks in parallel on the backend by spawning another "local" backend on each node.
+
+```
+--max-tasks-per-node MAX_TASKS_PER_NODE
+```
+
+- Maximum number of simultaneous tasks to process with each node.
+
 ### Config
 By default, onager will simply launch commands for you. If you need to do additional initialization or cleanup, you can configure it using the `config` subcommand and writing to the `header` or `footer` fields of the appropriate backend.
 

--- a/onager/frontend.py
+++ b/onager/frontend.py
@@ -27,10 +27,10 @@ def parse_args(args=None):
     prelaunch_parser.add_argument('+flag', type=str, action='append', metavar=('--flag'),
         help='Add a boolean argument that will be toggled in the resulting commands')
     prelaunch_parser.add_argument('+tag', type=str, nargs='?', const='--tag',
-        help='Passes unique str for each run to this arg in command, i.e. +tag <run-tag> <str>')
+        help='Passes a unique tag string for each run to the specified arg in the command, i.e. --tag <tag-contents>')
     prelaunch_parser.add_argument('+tag-args', type=str, nargs='+',
         metavar=('--argname'),
-        help='Specifies which args go into the unique <str>. Default is all provided +arg')
+        help='Specifies which args go into the unique <tag-contents>. Default is all provided args')
     prelaunch_parser.add_argument('+no-tag-number', action='store_true', dest='no_tag_number',
         help='Disable auto-numbering when generating tags')
     prelaunch_parser.add_argument('+a', '+append', action='store_true', dest='append',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='onager',
-    version='0.1.2',
+    version='0.1.3',
     description='Lightweight python library for launching experiments and tuning hyperparameters, either locally or on a cluster',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Release notes:
- Add support for `prelaunch` option `+no-tag-number` to disable auto-numbering when generating tags.
- Add multiworker `launch` support (via `--tasks-per-node` and `--max-tasks-per-node`) to allow nodes on the backend to spawn their own _local_ backends for processing tasks in parallel.
- Update documentation