### PR TITLE
Implement history subcommand

### DIFF
--- a/bin/onager
+++ b/bin/onager
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
-import os
 
 from onager import frontend
-from onager import meta_launcher, launcher, cancel, config, utils
+from onager import meta_launcher, launcher, history, cancel, config, utils
 from onager import list as list_
 
 if __name__ == '__main__':
@@ -14,6 +13,8 @@ if __name__ == '__main__':
         meta_launcher.meta_launch(args)
     elif args.subcommand == 'launch':
         launcher.launch(args, other_args)
+    elif args.subcommand == 'history':
+        history.print_history(args)
     elif args.subcommand == 'list':
         list_.list_commands(args)
     elif args.subcommand == 'cancel':

--- a/onager/backends/_backend.py
+++ b/onager/backends/_backend.py
@@ -4,8 +4,8 @@ import subprocess
 import sys
 
 from ..config import get_active_config
-from ..constants import default_logs_folder, job_index
-from ..utils import update_index, insert_second_to_last
+from ..constants import default_logs_folder
+from ..utils import update_jobindex, insert_second_to_last
 from ..history import add_new_history_entry
 
 class Backend:
@@ -96,5 +96,5 @@ class Backend:
                     print(err)
                     sys.exit()
         job_entries = [(jobid, args.jobname, args.jobfile) for jobid in jobids]
-        update_index(job_entries, index_name=job_index, append=True)
+        update_jobindex(job_entries, append=True)
         add_new_history_entry(args.dry_run)

--- a/onager/backends/_backend.py
+++ b/onager/backends/_backend.py
@@ -4,8 +4,9 @@ import subprocess
 import sys
 
 from ..config import get_active_config
-from ..constants import default_logs_folder
-from ..utils import update_jobindex, insert_second_to_last
+from ..constants import default_logs_folder, job_index
+from ..utils import update_index, insert_second_to_last
+from ..history import add_new_history_entry
 
 class Backend:
     def __init__(self):
@@ -95,4 +96,5 @@ class Backend:
                     print(err)
                     sys.exit()
         job_entries = [(jobid, args.jobname, args.jobfile) for jobid in jobids]
-        update_jobindex(job_entries, append=True)
+        update_index(job_entries, index_name=job_index, append=True)
+        add_new_history_entry(args.dry_run)

--- a/onager/backends/local.py
+++ b/onager/backends/local.py
@@ -4,8 +4,10 @@ import os
 import socket
 
 from ._backend import Backend
+from ..constants import job_index
+from ..history import add_new_history_entry
 from ..worker import run_command_by_id
-from ..utils import expand_ids, load_jobfile, update_jobindex, get_next_index_jobid, cpu_count
+from ..utils import expand_ids, load_jobfile, update_index, get_next_index_id, cpu_count
 
 class LocalBackend(Backend):
     def __init__(self, logging_name=None):
@@ -51,8 +53,9 @@ class LocalBackend(Backend):
         os.makedirs(os.path.dirname(self.log_path), exist_ok=True)
         task_ids = expand_ids(args.tasklist)
 
-        job_entries = [(get_next_index_jobid(), args.jobname, args.jobfile)]
-        update_jobindex(job_entries, append=True)
+        job_entries = [(get_next_index_id(), args.jobname, args.jobfile)]
+        update_index(job_entries, index_name=job_index, append=True)
+        add_new_history_entry(args.dry_run)
 
         n_workers = self.get_n_workers(task_ids, args.max_tasks, args.cpus)
         if not args.dry_run:

--- a/onager/backends/local.py
+++ b/onager/backends/local.py
@@ -4,10 +4,9 @@ import os
 import socket
 
 from ._backend import Backend
-from ..constants import job_index
 from ..history import add_new_history_entry
 from ..worker import run_command_by_id
-from ..utils import expand_ids, load_jobfile, update_index, get_next_index_id, cpu_count
+from ..utils import expand_ids, load_jobfile, update_jobindex, get_next_index_id, cpu_count
 
 class LocalBackend(Backend):
     def __init__(self, logging_name=None):
@@ -54,7 +53,7 @@ class LocalBackend(Backend):
         task_ids = expand_ids(args.tasklist)
 
         job_entries = [(get_next_index_id(), args.jobname, args.jobfile)]
-        update_index(job_entries, index_name=job_index, append=True)
+        update_jobindex(job_entries, append=True)
         add_new_history_entry(args.dry_run)
 
         n_workers = self.get_n_workers(task_ids, args.max_tasks, args.cpus)

--- a/onager/constants.py
+++ b/onager/constants.py
@@ -4,7 +4,8 @@ import os
 onager_folder = '.onager'
 default_scripts_folder = os.path.join(onager_folder, 'scripts')
 default_logs_folder = os.path.join(onager_folder, 'logs')
-default_index = os.path.join(onager_folder, 'job_index.csv') # id,jobname,jobfile_path
+job_index = os.path.join(onager_folder, 'job_index.csv') # id,jobname,jobfile_path
+history_index = os.path.join(onager_folder, 'history_index.csv')
 defaultjobfile = os.path.join(default_scripts_folder, '{jobname}', 'jobs.json')
 globalconfigfile = os.path.join(os.path.expanduser('~'), '.onagerconfig')
 localconfigfile = os.path.join(onager_folder, 'config')

--- a/onager/frontend.py
+++ b/onager/frontend.py
@@ -84,6 +84,10 @@ def parse_args(args=None):
     history_parser.add_argument('--prelaunch', action='store_true', help='Show prelaunch commands')
     history_parser.add_argument('--launch', action='store_true', help='Show launch commands')
     history_parser.add_argument('--no-dry-run', action='store_true', help='Hide dry-run commands')
+    history_parser.add_argument('-n', metavar='N', type=int, default=None,
+        help='Limit output to the most recent N entries')
+    history_parser.add_argument('--since', type=str, nargs='+', metavar=('DATE', 'TIME'),
+        default=None, help='Show commands since DATE (YYYY.mm.dd) [and TIME (hh:mm:ss)]')
 
 
     list_parser = subparsers.add_parser('list',
@@ -129,7 +133,7 @@ def parse_args(args=None):
     help_parser = subparsers.add_parser('help',
         help='Show usage information for a subcommand')
     help_parser.add_argument('help_command', type=str, nargs='?',
-        choices=['prelaunch', 'launch', 'list', 'cancel', 'config', 'help'],
+        choices=['prelaunch', 'launch', 'history', 'list', 'cancel', 'config', 'help'],
         help='Get help about a subcommand')
     # yapf: enable
 

--- a/onager/frontend.py
+++ b/onager/frontend.py
@@ -87,7 +87,7 @@ def parse_args(args=None):
     history_parser.add_argument('-n', metavar='N', type=int, default=None,
         help='Limit output to the most recent N entries')
     history_parser.add_argument('--since', type=str, nargs='+', metavar=('DATE', 'TIME'),
-        default=None, help='Show commands since DATE (YYYY.mm.dd) [and TIME (hh:mm:ss)]')
+        default=None, help='Show commands since DATE (YYYY.mm.dd) [and TIME (HH:MM:SS)]')
 
 
     list_parser = subparsers.add_parser('list',

--- a/onager/frontend.py
+++ b/onager/frontend.py
@@ -79,6 +79,13 @@ def parse_args(args=None):
     launch_parser.add_argument('-q', '--quiet', action='store_true', help='Quiet output')
 
 
+    history_parser = subparsers.add_parser('history',
+        help='Display command history')
+    history_parser.add_argument('--prelaunch', action='store_true', help='Show prelaunch commands')
+    history_parser.add_argument('--launch', action='store_true', help='Show launch commands')
+    history_parser.add_argument('--no-dry-run', action='store_true', help='Hide dry-run commands')
+
+
     list_parser = subparsers.add_parser('list',
         help='List previously launched commands by job_id and task_id')
     list_parser.add_argument('-j','--jobid', type=str,

--- a/onager/history.py
+++ b/onager/history.py
@@ -63,6 +63,7 @@ def print_history(args, quiet=False):
         matches_prelaunch = (entry.mode == 'prelaunch') and args.prelaunch
 
         if args.since is not None:
+            assert len(args.since) <= 2
             date_str, time_str, *_ = args.since + ['00:00:00'] # use midnight if no time specified
             format_str = '%Y.%m.%d %H:%M:%S'
             since_datetime = datetime.strptime(date_str+' '+time_str, format_str)

--- a/onager/history.py
+++ b/onager/history.py
@@ -76,10 +76,10 @@ def print_history(args, quiet=False):
         filtered = (entry.dry_run and args.no_dry_run)
         return valid_mode and matches_datetime and not filtered
 
-    printable_history = [make_printable(entry) for entry in history_entries if should_print(entry)]
-    if args.n is not None:
-        assert args.n > 0
-        printable_history = printable_history[-args.n:]
+    N = args.n or len(history_entries)
+    printable_history = [
+        make_printable(entry) for entry in history_entries[-N:] if should_print(entry)
+    ]
 
     fields = [field for field in HistoryEntry._fields if field not in ['mode', 'dry_run']]
     if not quiet:

--- a/onager/history.py
+++ b/onager/history.py
@@ -1,0 +1,73 @@
+from collections import namedtuple
+from datetime import datetime
+import sys
+
+from tabulate import tabulate
+
+from .constants import history_index
+from .utils import load_index, update_index, get_next_index_id
+
+HistoryEntry = namedtuple('HistoryEntry', ['id', 'date', 'time', 'mode', 'dry_run', 'command'])
+
+def make_history_entry(cmd_id, date, time, mode, dry_run, command, args):
+    assert dry_run in ['y', 'n']
+    entry = HistoryEntry(cmd_id, date, time, mode, (dry_run == 'y'), command)
+    if 'hide' in args and args.hide is not None:
+        entry = entry._asdict()
+        for field in HistoryEntry._fields:
+            if field in args.hide:
+                entry[field] = '[hidden]'
+        entry = HistoryEntry(**entry)
+    return entry
+
+def add_new_history_entry(dry_run):
+    now = datetime.now()
+    history_entry = HistoryEntry(
+        id=get_next_index_id(history_index),
+        date=now.strftime('%Y.%m.%d'),
+        time=now.strftime('%H:%M:%S.%f'),
+        mode=sys.argv[1],
+        dry_run=dry_run,
+        command=' '.join(sys.argv[1:]),
+    )
+    update_index([get_history_tuple(history_entry)], history_index, append=True)
+
+
+def get_history_tuple(entry: HistoryEntry) -> str:
+    return str(entry.id), entry.date, entry.time, entry.mode, ('y' if entry.dry_run else 'n'), entry.command
+
+def get_history(args):
+    history_list = []
+    try:
+        index = load_index(history_index)
+    except (IOError):
+        return history_list
+    for cmd_id, cmd_details in index.items():
+        entry = make_history_entry(
+            cmd_id,
+            *cmd_details,
+            args
+        )
+        history_list.append(entry)
+    return history_list
+
+def print_history(args, quiet=False):
+    """Prints onager command history"""
+    history_entries = get_history(args)
+    def make_printable(entry):
+        return str(entry.id), entry.date, entry.time, entry.command
+
+    def should_print(entry):
+        no_mode_specified = not (args.prelaunch or args.launch)
+        matches_launch = (entry.mode == 'launch') and args.launch
+        matches_prelaunch = (entry.mode == 'prelaunch') and args.prelaunch
+
+        valid_mode = no_mode_specified or matches_launch or matches_prelaunch
+        filtered = (entry.dry_run and args.no_dry_run)
+        return valid_mode and not filtered
+
+    printable_history = [make_printable(entry) for entry in history_entries if should_print(entry)]
+
+    fields = [field for field in HistoryEntry._fields if field not in ['mode', 'dry_run']]
+    if not quiet:
+        print(tabulate(printable_history, headers=fields))

--- a/onager/list.py
+++ b/onager/list.py
@@ -1,10 +1,8 @@
 from collections import namedtuple
-import subprocess
-import sys
 
 from tabulate import tabulate
 
-from .utils import load_jobindex, expand_ids, load_jobfile
+from .utils import load_index, expand_ids, load_jobfile
 
 JobListing = namedtuple('JobListing', ['job_id', 'task_id', 'jobname', 'command', 'tag'])
 
@@ -26,7 +24,7 @@ def get_job_listings(args):
 
     job_list = []
     try:
-        index = load_jobindex()
+        index = load_index()
     except (IOError):
         return job_list
     for jobid in index.keys():
@@ -53,4 +51,3 @@ def list_commands(args, quiet=False):
     job_list = get_job_listings(args)
     if not quiet:
         print(tabulate(job_list, headers=JobListing._fields))
-    

--- a/onager/list.py
+++ b/onager/list.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 from tabulate import tabulate
 
-from .utils import load_index, expand_ids, load_jobfile
+from .utils import load_jobindex, expand_ids, load_jobfile
 
 JobListing = namedtuple('JobListing', ['job_id', 'task_id', 'jobname', 'command', 'tag'])
 
@@ -24,7 +24,7 @@ def get_job_listings(args):
 
     job_list = []
     try:
-        index = load_index()
+        index = load_jobindex()
     except (IOError):
         return job_list
     for jobid in index.keys():

--- a/onager/meta_launcher.py
+++ b/onager/meta_launcher.py
@@ -4,6 +4,7 @@ from warnings import warn
 
 from .utils import load_jobfile, save_jobfile
 from .constants import SEP, WSEP, FLAG_ON, FLAG_OFF
+from .history import add_new_history_entry
 
 def meta_launch(args):
     base_cmd = args.command
@@ -133,3 +134,4 @@ def meta_launch(args):
         jobs[i] = (cmd,tag)
 
     save_jobfile(jobs, jobfile_path, args.tag)
+    add_new_history_entry(dry_run=False)

--- a/onager/utils.py
+++ b/onager/utils.py
@@ -77,6 +77,9 @@ def update_index(entries, index_name:str, append=True):
 def update_jobindex(entries, append=True):
     update_index(entries, index_name=constants.job_index, append=append)
 
+def load_jobindex():
+    load_index(index_name=constants.job_index)
+
 def condense_ids(id_list):
     G = (list(x) for _, x in groupby(id_list, lambda x, c=count(): next(c) - x))
     return ",".join("-".join(map(str, (g[0], g[-1])[:len(g)])) for g in G)

--- a/onager/utils.py
+++ b/onager/utils.py
@@ -51,28 +51,28 @@ def compute_subjobs_filename(jobfile_path):
     jobdir = os.path.dirname(jobfile_path)
     return os.path.join(jobdir, 'subjobs.csv')
 
-def load_jobindex():
-    with open(constants.default_index, 'r', newline='') as job_index:
-        csv_reader = csv.reader(job_index, delimiter=',', quotechar='|')
-        index = {job_entry[0]: job_entry[1:] for job_entry in csv_reader}
+def load_index(index_name:str = constants.job_index):
+    with open(index_name, 'r', newline='') as index_file:
+        csv_reader = csv.reader(index_file, delimiter=',', quotechar='|')
+        index = {entry[0]: entry[1:] for entry in csv_reader}
     return index
 
-def get_next_index_jobid():
+def get_next_index_id(index_name:str = constants.job_index):
     try:
-        ids = load_jobindex().keys()
+        ids = load_index(index_name).keys()
     except IOError:
         ids = []
     try:
-        next_jobid = max(map(int,ids)) + 1
+        next_id = max(map(int,ids)) + 1
     except ValueError:
-        next_jobid = 0
-    return next_jobid
+        next_id = 0
+    return next_id
 
-def update_jobindex(job_entries, append=True):
+def update_index(entries, index_name:str = constants.job_index, append=True):
     mode = 'w+' if not append else 'a+'
-    with open(constants.default_index, mode, newline='') as job_index:
-        csv_writer = csv.writer(job_index, delimiter=',', quotechar='|')
-        csv_writer.writerows(job_entries)
+    with open(index_name, mode, newline='') as index_file:
+        csv_writer = csv.writer(index_file, delimiter=',', quotechar='|')
+        csv_writer.writerows(entries)
 
 def condense_ids(id_list):
     G = (list(x) for _, x in groupby(id_list, lambda x, c=count(): next(c) - x))

--- a/onager/utils.py
+++ b/onager/utils.py
@@ -68,11 +68,14 @@ def get_next_index_id(index_name:str = constants.job_index):
         next_id = 0
     return next_id
 
-def update_index(entries, index_name:str = constants.job_index, append=True):
+def update_index(entries, index_name:str, append=True):
     mode = 'w+' if not append else 'a+'
     with open(index_name, mode, newline='') as index_file:
         csv_writer = csv.writer(index_file, delimiter=',', quotechar='|')
         csv_writer.writerows(entries)
+
+def update_jobindex(entries, append=True):
+    update_index(entries, index_name=constants.job_index, append=append)
 
 def condense_ids(id_list):
     G = (list(x) for _, x in groupby(id_list, lambda x, c=count(): next(c) - x))


### PR DESCRIPTION
Closes #48.

Uses existing load/update/get_next_id functionality for job index, but renames variables so those functions are agnostic to the type of index (and adds an arg which allows the index name to be specified)