### PR TITLE
add default enforce-binding flag for SLURM GPU

### DIFF
--- a/onager/backends/slurm.py
+++ b/onager/backends/slurm.py
@@ -44,7 +44,7 @@ class SlurmBackend(Backend):
             raise RuntimeError('{}: Duration cannot exceed 2 hours while in debug/test mode.'.format(self.name))
         if args.gpus > 0:
             partition = 'gpu-debug' if args.debug else 'gpu'
-            base_cmd += '-p {} --gres=gpu:{} '.format(partition, args.gpus)
+            base_cmd += '-p {} --gres=gpu:{} --gres-flags=enforce-binding'.format(partition, args.gpus)
         else:
             partition = 'debug' if args.debug else 'batch'
             base_cmd += '-p {} '.format(partition)


### PR DESCRIPTION
Singh Saluja mentions that: 

chedMD recommends using `--gres-flags=enforce-binding` flag that ensures all GPUs are allocated on the same CPU socket.