### PR TITLE
`+exclude` functionality!

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ onager launch --backend slurm --jobname experiment1
 Output:
 ```
 sbatch -J experiment1 -t 0-01:00:00 -n 1 -p batch --mem=2G -o .onager/logs/slurm/%x_%A_%a.o -e .onager/logs/slurm/%x_%A_%a.e --parsable --array=1,2,3,4,5,6,7,8,9 .onager/scripts/experiment1/wrapper.sh
-```  
+```
 
 Options:
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Argument types:
 ```
 +exclude --argname [value ...]
 ```
-- Exclude certain argument values. If multiple `+exclude` arguments given, 
+- Exclude certain named argument values. If multiple `+exclude` arguments given, 
 will exclude the _product_ of all `+exclude` arguments. So for example:
 
 ```

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Argument types:
 
 - Add a boolean argument that will be toggled in the resulting commands
 
+```
++exclude --argname [value ...]
+```
+- Exclude certain argument values. If multiple `+exclude` arguments given, 
+will exclude the _product_ of all `+exclude` arguments. 
 
 Options:
 ```

--- a/README.md
+++ b/README.md
@@ -50,44 +50,66 @@ myscript --learningrate 0.1 --batchsize 128 --mytag experiment1_7__learningrate_
 myscript --learningrate 0.01 --batchsize 128 --mytag experiment1_8__learningrate_0.01__batchsize_128
 myscript --learningrate 0.001 --batchsize 128 --mytag experiment1_9__learningrate_0.001__batchsize_128
 ```
+<br>
 
 Argument types:
+
+#### Named Argument
 ```
 +arg --argname [value ...]
 ```
 - Add an argument with zero or more mutually exclusive values
 
+#### Positional Argument
 ```
 +pos-arg value [value ...]
 ```
 
 - Add a positional argument with one or more mutually exclusive values
 
+#### Flag
 ```
 +flag --flagname
 ```
 
 - Add a boolean argument that will be toggled in the resulting commands
 
+#### Exclusions
 ```
 +exclude --argname [value ...]
 ```
 - Exclude certain argument values. If multiple `+exclude` arguments given, 
-will exclude the _product_ of all `+exclude` arguments. 
+will exclude the _product_ of all `+exclude` arguments. So for example:
+
+```
+onager prelaunch +jobname job1 +command myscript +arg --first 1 2 3 +arg --second 4 5 +exclude --first 1 2 +exclude --second 5
+```
+will generate the runs:
+```
+myscript --first 1 --second 4
+myscript --first 2 --second 4
+myscript --first 3 --second 4
+myscript --first 3 --second 5
+```
+<br>
 
 Options:
+
+#### Tag
 ```
 +tag [TAG]
 ```
 
 - Passes a unique tag string for each run to the specified arg in the command, i.e. `--tag <tag-contents>`.
 
+#### Tag Contents
 ```
 +tag-args --argname [--argname ...]
 ```
 
 - Specifies which args go into the unique `<tag-contents>`. Default is all provided args.
 
+#### Remove Tag Numbering
 ```
 +no-tag-number
 ```
@@ -105,7 +127,7 @@ onager launch --backend slurm --jobname experiment1
 Output:
 ```
 sbatch -J experiment1 -t 0-01:00:00 -n 1 -p batch --mem=2G -o .onager/logs/slurm/%x_%A_%a.o -e .onager/logs/slurm/%x_%A_%a.e --parsable --array=1,2,3,4,5,6,7,8,9 .onager/scripts/experiment1/wrapper.sh
-```
+```  
 
 Options:
 ```

--- a/onager/constants.py
+++ b/onager/constants.py
@@ -1,7 +1,7 @@
 import os
 
 # Basic constants
-onager_folder = '.onager'
+onager_folder = os.path.dirname(os.environ['VIRTUAL_ENV']) + '/.onager'
 default_scripts_folder = os.path.join(onager_folder, 'scripts')
 default_logs_folder = os.path.join(onager_folder, 'logs')
 job_index = os.path.join(onager_folder, 'job_index.csv') # id,jobname,jobfile_path

--- a/onager/constants.py
+++ b/onager/constants.py
@@ -1,7 +1,7 @@
 import os
 
 # Basic constants
-onager_folder = os.path.dirname(os.environ['VIRTUAL_ENV']) + '/.onager'
+onager_folder = '.onager'
 default_scripts_folder = os.path.join(onager_folder, 'scripts')
 default_logs_folder = os.path.join(onager_folder, 'logs')
 job_index = os.path.join(onager_folder, 'job_index.csv') # id,jobname,jobfile_path

--- a/onager/frontend.py
+++ b/onager/frontend.py
@@ -23,6 +23,9 @@ def parse_args(args=None):
     prelaunch_parser.add_argument('+arg', type=str, action='append', nargs='+',
         metavar=('--argname', 'value'),
         help='Add an argument with zero or more mutually exclusive values')
+    prelaunch_parser.add_argument('+exclude', type=str,  action='append', nargs='+',
+        help='Exclude arguments. Specify arg and Onager will exclude'
+             'a cross-product of all +exclude args.')
     prelaunch_parser.add_argument('+pos-arg', type=str, action='append', nargs='+',
         metavar=('value', 'value'),
         help='Add a positional argument with one or more mutually exclusive values')

--- a/onager/meta_launcher.py
+++ b/onager/meta_launcher.py
@@ -92,7 +92,7 @@ def meta_launch(args):
     for key, value_list in variables.items():
         cmd_prefix_list = [prefix + ' ' + key for prefix in cmd_prefix_list]
         if len(value_list) > 0:
-            cmd_prefix_list = [prefix + VAR_SEP +'{}' for prefix in cmd_prefix_list]
+            cmd_prefix_list = [prefix + VAR_SEP + '{}' for prefix in cmd_prefix_list]
             cmd_prefix_list = [prefix.format(v) for v in value_list for prefix in cmd_prefix_list]
         if args.tag is not None:
             if key in args.tag_args:

--- a/onager/meta_launcher.py
+++ b/onager/meta_launcher.py
@@ -161,7 +161,7 @@ def meta_launch(args):
             print(cmd)
         jobs[i] = (cmd,tag)
 
-    print(f"Prelaunched {len(jobs)} jobs for")
+    print(f"Prelaunched {len(jobs)} jobs for {args.jobname}.")
 
     save_jobfile(jobs, jobfile_path, args.tag)
     add_new_history_entry(jobname=args.jobname, dry_run=False)

--- a/onager/meta_launcher.py
+++ b/onager/meta_launcher.py
@@ -17,7 +17,7 @@ def filter_cmd_prefix(exclude_variables, cmd_prefix_list, VAR_SEP=' '):
 
     filtered_prefix_list = []
     for cmd_prefix in cmd_prefix_list:
-        all_keys_match = True
+        all_keys_match = True if exclude_arg_keys else False
         for curr_key_strs in exclude_arg_keys:
             all_keys_match &= any(key_str in cmd_prefix for key_str in curr_key_strs)
 

--- a/onager/meta_launcher.py
+++ b/onager/meta_launcher.py
@@ -28,6 +28,7 @@ def filter_cmd_prefix(exclude_variables, cmd_prefix_list, VAR_SEP=' '):
             filtered_prefix_list.append(cmd_prefix)
 
     return filtered_prefix_list
+
 def meta_launch(args):
     base_cmd = args.command
 
@@ -159,6 +160,8 @@ def meta_launch(args):
         if not args.quiet:
             print(cmd)
         jobs[i] = (cmd,tag)
+
+    print(f"Prelaunched {len(jobs)} jobs for")
 
     save_jobfile(jobs, jobfile_path, args.tag)
     add_new_history_entry(jobname=args.jobname, dry_run=False)

--- a/tests/test_prelaunch.py
+++ b/tests/test_prelaunch.py
@@ -160,6 +160,15 @@ class TestPrelaunchOptionalArgs(unittest.TestCase):
         jobs = run_meta_launcher(cmd)
         self.assertEqual("echo --value 1 --tag testecho_01__value_1", jobs[0][1])
 
+class TestPrelaunchExclude(unittest.TestCase):
+    def test_cross_product(self):
+        cmd = "prelaunch +command test +jobname test " \
+              "+arg --test1 1 2 3 +arg --test2 4 5 6 +exclude --test1 1 2 +exclude --test2 5"
+        jobs = run_meta_launcher(cmd)
+        self.assertEqual(len(jobs[0]), 7)
+        for job in jobs[0]:
+            self.assertNotIn('--test2 5' and '--test1 1', job)
+            self.assertNotIn('--test2 5' and '--test1 2', job)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As mentioned in #53, this PR is for the `+exclude` functionality. `+exclude` removes a subset of the runs generated by `+args`, by removing all runs that include arguments with the cross product of all `+exclude` hyperparams. So for example:

`prelaunch +command test +jobname test +arg --test1 1 2 3 +arg --test2 4 5 6 +exclude --test1 1 2 +exclude --test2 5`

Should exclude all jobs with arguments

- `--test1 1 --test2 5`
- `--test1 2 --test2 5`

I've also written a test according to this example, but am unsure of how to run the test...